### PR TITLE
filter deprecated resources

### DIFF
--- a/openapi-ts.config.ts
+++ b/openapi-ts.config.ts
@@ -3,4 +3,9 @@ import { defineConfig } from '@hey-api/openapi-ts';
 export default defineConfig({
   input: 'https://api.stellarcarbon.io/openapi.json',
   output: 'src/',
+  parser: { 
+    filters: { 
+      deprecated: false, 
+    }, 
+  },
 });


### PR DESCRIPTION
Should we exclude deprecated resources from the SDK? I think that would be best.

The reason we mark resources as deprecated is to allow for a smooth transition, some time for users to upgrade to the latest API version. As soon as they upgrade to the latest SDK, they shouldn't keep using these deprecated resources.